### PR TITLE
Add SendWyre Lending Popup

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -18,6 +18,7 @@
         <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
         <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
         <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+        <script src="https://verify.sendwyre.com/js/verify-module-init-beta.js"></script>
         <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/fortmatic@latest/dist/fortmatic.js"></script>
 

--- a/src/components/LendingSection/index.scss
+++ b/src/components/LendingSection/index.scss
@@ -1,5 +1,5 @@
 .lending-card {
-  height: 20rem;
+  height: 24rem;
   .supply-button {
     margin-top: 2rem;
   }

--- a/src/components/LendingSection/index.tsx
+++ b/src/components/LendingSection/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from "react";
+import Wyre from 'wyre';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -57,8 +58,6 @@ const completeRedeemZDai = (state: any, updateAppState: Function) => async () =>
       return { ...st, zeroCollateral };
     });
   } catch (error) {
-    error
-    debugger
     updateAppState((st: AppContextState) => {
       const errorModal = {
         show: true,
@@ -70,10 +69,27 @@ const completeRedeemZDai = (state: any, updateAppState: Function) => async () =>
   }
 };
 
+const wyrePopup = amount => new Wyre({
+    env: 'test',
+    operation: {
+        type: 'debitcard-hosted-dialog',
+        dest: "ethereum:0x98B031783d0efb1E65C4072C6576BaCa0736A912",
+        destCurrency: "ETH",
+        sourceAmount: amount,
+        paymentMethod: 'debit-card'
+    }
+});
+
 const LendingCard = () => {
   const { state, updateAppState } = useContext(AppContext);
   const initialSupplyValues = { amount: 100 };
   const hasWeb3 = state.web3State?.web3;
+
+
+  const openDebit = () => {
+    const wyre = wyrePopup(100);
+    wyre.open();
+  };
 
   return <Card className="lending-card px-5 w-100 shadow">
     <Card.Body>
@@ -118,6 +134,11 @@ const LendingCard = () => {
                   </Form>
                 )}
             </Formik>
+          </Col>
+        </Row>
+        <Row className="justify-content-center mt-2">
+          <Col xs={{span: 4, offset: 0 }}>
+            <Button onClick={openDebit} disabled={!hasWeb3} className="supply-debit-button" variant="success" block>Supply with Debit Card</Button>
           </Col>
         </Row>
       </Container>

--- a/src/index.d.tsx
+++ b/src/index.d.tsx
@@ -3,3 +3,4 @@ declare module '*.jpg'
 declare module '*.svg'
 declare module 'bnc-notify';
 declare module 'bnc-onboard';
+declare module 'wyre';

--- a/src/util/constants.tsx
+++ b/src/util/constants.tsx
@@ -2,7 +2,7 @@ var serverURL: string;
 if (process.env.NODE_ENV === 'production') {
   serverURL = '';
 } else {
-  serverURL = 'http://web2-elb-ntwrk-94efa0b9d1e72695.elb.us-west-2.amazonaws.com/';
+  serverURL = 'ec2-54-212-133-240.us-west-2.compute.amazonaws.com';
 }
 
 export const fortmaticOptions = {

--- a/src/util/constants.tsx
+++ b/src/util/constants.tsx
@@ -2,8 +2,9 @@ var serverURL: string;
 if (process.env.NODE_ENV === 'production') {
   serverURL = '';
 } else {
-  serverURL = 'ec2-54-212-133-240.us-west-2.compute.amazonaws.com';
+  serverURL = 'http://ec2-54-212-133-240.us-west-2.compute.amazonaws.com';
 }
+
 
 export const fortmaticOptions = {
   apiKey: process.env.FORTMATIC_API_KEY || "pk_test_DE7A33DFF78D95FD",

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -86,6 +86,7 @@ module.exports = {
         "react": "React",
         "react-dom": "ReactDOM",
         "plaid-files": "Plaid",
-        "fortmatic": "Fortmatic"
+        "fortmatic": "Fortmatic",
+        "wyre": "Wyre"
     }
 };


### PR DESCRIPTION
## Description 

Adds SendWyre Popup to the lending card.

## Testing

1. `npm run start:dev` and go to localhost:3000.
2. Connect your Metamask (Ropsten) and click "Supply with Debit Card."
3. A popup for SendWyre should appear.

## Screenshots

![Screenshot from 2020-06-29 13-59-24](https://user-images.githubusercontent.com/1673206/86040217-a4c7f680-ba11-11ea-8151-f660981f1bd2.png)

![Screenshot from 2020-06-29 13-59-15](https://user-images.githubusercontent.com/1673206/86040228-aabdd780-ba11-11ea-8eec-ddeb0f5e3938.png)

## Reference Docs

https://docs.sendwyre.com/docs/wyre-widget-v2
